### PR TITLE
fix ensurefolder

### DIFF
--- a/lib/level-store.js
+++ b/lib/level-store.js
@@ -89,6 +89,7 @@ module.exports = function(opts) {
               return cb();
           }
           fs.mkdir(folder, function(err) {
+            if (err && err.code === 'EEXIST') err = null
             cb(err);
           });
         });


### PR DESCRIPTION
**ensurefolder** tries to **fs.mkdir** and returns error if any occurs. The problem is when **fs.mkdir** returns error stating that the folder already exists. **ensurefolder** sends that out as an error, which causes a snowballing effect.

As ensurefolder's role is to make sure folder exists, it shouldn't really return an error saying a folder exists, right?

Same as rjrodger/seneca-jsonfile-store/pull/8

Fixes rjrodger/seneca-level-store/issues/2
